### PR TITLE
Update - arp removed on latest OpenWRT

### DIFF
--- a/scripts/owrt_client_discovery.sh
+++ b/scripts/owrt_client_discovery.sh
@@ -22,15 +22,15 @@ do
         then
                 hostname=$(echo $nsreturn |awk '{print $4}')
         else
-                hostname=$ip
+                hostname=$mac
         fi
     # fallback if hostname is not found
     if [ -z "$hostname" ]
     then
-      hostname=$ip
+      hostname=$mac
     fi
   else
-    hostname=$ip
+    hostname=$mac
   fi
   detail="${detail}{\"{#NETWORK_CLIENT}\":\"$hostname\",\"{#MACADDR}\": \"$mac\",\"{#IPADDR}\": \"$ip\"},"
 done

--- a/scripts/owrt_client_discovery.sh
+++ b/scripts/owrt_client_discovery.sh
@@ -8,28 +8,32 @@
 IFS=$'\n'
 detail=""
 echo {\"data\":[
-for line in $(sudo /usr/sbin/nlbw -c csv -n -g mac -q|grep -v 00:00:00|tail -n+2)
+for line in $(sudo /usr/sbin/nlbw -c csv -n -g mac,ip,fam -q |grep -v 00:00:00|tail -n+2)
 # the grep -v 00:00:00 is here to prevent empty macs
 do
   # trying to get the hostname
-  mac=$(echo $line|awk '{print $1}')
-  # getting the ip
-  ip=$(arp -n |grep $mac)
-  if [ ?$ -eq 0 ]
+  # getting the mac & ip
+  mac=$(echo $line |awk '{print $2}')
+  ip=$(echo $line |awk '{print $3}')
+  if [ $? -eq 0 ]
   then
-    hostname=$(dig -x $(arp -n |grep $mac |awk '{print $2}'|awk -F'(' '{print $2}'| awk -F')' '{print $1}') +short)
-    # fallback if ho  stname is not found
+    nsreturn=$(nslookup $ip |grep "name =")
+        if [ $? -eq 0 ]
+        then
+                hostname=$(echo $nsreturn |awk '{print $4}')
+        else
+                hostname=$ip
+        fi
+    # fallback if hostname is not found
     if [ -z "$hostname" ]
     then
-      hostname=$mac
+      hostname=$ip
     fi
   else
-    hostname=$mac
+    hostname=$ip
   fi
-  detail="${detail}{\"{#NETWORK_CLIENT}\": \"$hostname\",\"{#MACADDR}\": \"$mac\"},"
+  detail="${detail}{\"{#NETWORK_CLIENT}\":\"$hostname\",\"{#MACADDR}\": \"$mac\",\"{#IPADDR}\": \"$ip\"},"
 done
 total=$(echo $detail|sed 's/.$//') # we delete the last "," from our $detail
 echo $total
 echo ]}
-
-


### PR DESCRIPTION
The arp command is no longer supported on the latest version of OpenWRT. In order to make this script work I have updated the nlbw command to return the IP and MAC addresses